### PR TITLE
refactor terminology "attack model and terminology" section 

### DIFF
--- a/source/new.rst
+++ b/source/new.rst
@@ -7,10 +7,10 @@ Securing communications against network adversaries
 
 To withstand network adversaries,
 peers must verify each other's keys
-to establish trustable e2e-encrypted communication. In this section we describe
+to establish guaranteed e2e-encrypted communication. In this section we describe
 protocols to securely setup a contact and to securely add a user to a group.
 
-Establishing trustable e2e-encrypted communication is
+Establishing guaranteed e2e-encrypted communication is
 particularly difficult
 in group communications
 where more than two peers communicate with each other.

--- a/source/new.rst
+++ b/source/new.rst
@@ -137,7 +137,7 @@ messages.
    Setup Contact protocol step 2.
 
 The protocol follows a single simple UI workflow:
-A peer "shows" bootstrap data
+A peer "shows" an invite code once
 that is then "read" by the other peer through a second channel.
 This means that,
 as opposed to current fingerprint verification workflows,
@@ -172,14 +172,14 @@ and convince the peer to verify it.
    sequenceDiagram
       participant A as Alice
       participant B as Bob
-      A-->>B: 1.a) bootstrap code
+      A-->>B: 1.a) invite code
       Note over B: 2.a) check for existing key
       B->>A: 2.b) vc-request message with INVITENUMBER
-      Note over A: 3.a) look up bootstrap by INVITENUMBER
+      Note over A: 3.a) look up invite code by INVITENUMBER
       Note over A: 3.b) (removed)
       Note over A: 3.c) process AC header
       A->>B: 3.d) vc-auth-required message with AC header
-      Note over B: 4.a) abort if key does not match FP from bootstrap
+      Note over B: 4.a) abort if key does not match FP from invite code
       B->>A: 4.b) vc-request-with-auth with Bob_FP and AUTH
       Note over A: 5.a) verify AUTH and key
       Note over A: 5.b) on failure alert user and abort
@@ -195,9 +195,9 @@ of the proposed UI and administrative message workflow
 for establishing a secure contact between two contacts,
 Alice and Bob.
 
-1. Alice sends a bootstrap code to Bob via the second channel.
+1. Alice sends a invite code to Bob via the second channel.
 
-   a) The bootstrap code consists of:
+   a) The invite code consists of:
 
    - Alice's Openpgp4 public key fingerprint ``Alice_FP``,
      which acts as a commitment to the
@@ -208,7 +208,7 @@ Alice and Bob.
    - a challenge ``INVITENUMBER`` of at least 8 bytes.
      This challenge is used by Bob's device in step 2b
      to prove to Alice's device
-     that it is the device that the bootstrap code was shared with.
+     that it is the device that the invite code was shared with.
      Alice's device uses this information in step 3
      to automatically accept Bob's contact request.
      This is in contrast with most messaging apps
@@ -226,7 +226,7 @@ Alice and Bob.
      ..
        TODO: Double-check if this explanation of the ``tokens`` table is correct
 
-2. Bob receives the bootstrap code and
+2. Bob receives the invite code and
 
    a) If Bob's device already knows a key with the fingerprint ``Alice_FP``
       that
@@ -239,7 +239,7 @@ Alice and Bob.
 
 3. Alice's device receives the "vc-request" message.
 
-   a) She looks up the bootstrap data for the ``INVITENUMBER``.
+   a) She looks up the invite code for the ``INVITENUMBER``.
    If the ``INVITENUMBER`` does not match
    then Alice terminates the protocol.
 
@@ -300,10 +300,10 @@ Alice and Bob.
 
 At the end of this protocol,
 Alice has learned and validated the contact information and Autocrypt key of Bob,
-the person to whom she sent the bootstrap code.
+the person to whom she sent the invite code.
 Moreover,
 Bob has learned and validated the contact information and Autocrypt key of Alice,
-the person who sent the bootstrap code to Bob.
+the person who sent the invite code to Bob.
 
 Requirements for the underlying encryption scheme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -331,7 +331,7 @@ An active attacker cannot break the security of the Setup Contact protocol
 Recall that an active attacker can
 read, modify, and create messages
 that are sent via a regular channel.
-The attacker cannot observe or modify the bootstrap code
+The attacker cannot observe or modify the invite code
 that Alice sends via the second channel.
 We argue that such an attacker cannot
 break the security of the Setup Contact protocol,
@@ -359,8 +359,8 @@ we do not consider dropping of messages further.
    However, Bob will detect this modification during step 4a,
    because the fake ``Alice-MITM`` key does not match
    the fingerprint ``Alice_FP``
-   that Alice sent to Bob in the bootstrap code.
-   (Recall that the bootstrap code is transmitted
+   that Alice sent to Bob in the invite code.
+   (Recall that the invite code is transmitted
    via the second channel
    the adversary cannot modify.)
 
@@ -412,7 +412,7 @@ we do not consider dropping of messages further.
      the fingerprint of the fake ``Bob-MITM`` key and
      a guess for the challenge ``AUTH``.
      The adversary cannot learn the challenge ``AUTH``:
-     it cannot observe the bootstrap code
+     it cannot observe the invite code
      transmitted via the second channel in step 1,
      and it cannot decrypt the message "vc-request-with-auth".
      Therefore,
@@ -544,7 +544,7 @@ so that Alice and Bob verify each other's keys.
 To ask for Bob's explicit consent we
 indicate that the messages are part of the verified group protocol,
 and include the group's identifier
-in the metadata part of the bootstrap code.
+in the metadata part of the verified-group invite code.
 
 More precisely:
 

--- a/source/new.rst
+++ b/source/new.rst
@@ -10,13 +10,13 @@ peers must verify each other's keys
 to establish trustable e2e-encrypted communication. In this section we describe
 protocols to securely setup a contact and to securely add a user to a group.
 
-Establishing a trustable e2e-encrypted communication channel is
+Establishing trustable e2e-encrypted communication is
 particularly difficult
 in group communications
 where more than two peers communicate with each other.
 Existing messaging systems usually require peers to verify keys with every other
-peer to assert that they have a trustable e2e-encrypted channel.
-This is highly impractical.
+peer to assert that they have guaranteed e2e-encryption.
+This is highly unpractical.
 First,
 the number of verifications that a single peer must perform becomes
 too costly even for small groups.
@@ -99,7 +99,7 @@ and can be carried out automatically
 by replacing Autocrypt headers.
 
 With the SecureJoin protocols we aim to increase the costs of active attacks
-by introducing a second channel
+by introducing a second out-of-band channel
 and using it to verify the Autocrypt headers
 transmitted in-band.
 
@@ -138,7 +138,7 @@ messages.
 
 The protocol follows a single simple UI workflow:
 A peer "shows" an invite code once
-that is then "read" by the other peer through a second channel.
+that is then "read" by the other peer through an out-of-band channel.
 This means that,
 as opposed to current fingerprint verification workflows,
 the protocol only runs once instead of twice,
@@ -146,17 +146,18 @@ yet results in the two peers having verified keys of each other.
 
 Between mobile phones,
 showing and scanning a QR code
-constitutes a second channel,
-but transferring data via USB, Bluetooth, WLAN channels or phone calls
+constitutes an out-of-band channel,
+but transferring data via USB, Bluetooth, WLAN
+or other network-adversary resilient messengers
 is possible as well.
 
 Recall that
 we assume that
 our active attacker *cannot* observe or modify data transferred
-via the second channel.
+via the out-of-band channel.
 
 An attacker who can alter messages
-but has no way of reading or manipulating the second channel
+but has no way of reading or manipulating the out-of-band channel
 can prevent the verification protocol
 from completing successfully
 by dropping or altering messages.
@@ -195,7 +196,7 @@ of the proposed UI and administrative message workflow
 for establishing a secure contact between two contacts,
 Alice and Bob.
 
-1. Alice sends a invite code to Bob via the second channel.
+1. Alice sends a invite code to Bob via the out-of-band channel.
 
    a) The invite code consists of:
 
@@ -332,7 +333,7 @@ Recall that an active attacker can
 read, modify, and create messages
 that are sent via a regular channel.
 The attacker cannot observe or modify the invite code
-that Alice sends via the second channel.
+that Alice sends via the out-of-band channel.
 We argue that such an attacker cannot
 break the security of the Setup Contact protocol,
 that is, the attacker cannot
@@ -361,7 +362,7 @@ we do not consider dropping of messages further.
    the fingerprint ``Alice_FP``
    that Alice sent to Bob in the invite code.
    (Recall that the invite code is transmitted
-   via the second channel
+   via the out-of-band channel
    the adversary cannot modify.)
 
 2. The adversary also cannot impersonate Bob to Alice,
@@ -413,7 +414,7 @@ we do not consider dropping of messages further.
      a guess for the challenge ``AUTH``.
      The adversary cannot learn the challenge ``AUTH``:
      it cannot observe the invite code
-     transmitted via the second channel in step 1,
+     transmitted via the out-of-band in step 1,
      and it cannot decrypt the message "vc-request-with-auth".
      Therefore,
      this guess will only be correct with probability :math:`2^{-64}`.
@@ -702,7 +703,7 @@ strategy.
 
   In this case keys can be reused accross verified groups.
   Active attacks from an adversary
-  who can only modify messages in the first channel
+  who can only modify messages in the regular transport channel
   are still impossible.
 
   A malicious verified contact may inject MITM keys.

--- a/source/summary.rst
+++ b/source/summary.rst
@@ -120,19 +120,19 @@ by integrating key verification into existing messaging use cases:
   Alice and Bob know each other's contact information and
   have verified each other's keys.
   To do so,
-  Alice sends an *invite code* using using the second channel to Bob (for
-  example, by showing QR code).
+  Alice sends an *invite code* using the second channel to Bob (for
+  example, by showing it as a QR code).
   The invite code
   transfers not only the key fingerprint,
   but also contact information (e.g., email address).
   After receiving the second-channel invite code, Alice's and Bob's clients
-  communicate via the first channel to 1) exchange Bob's key and contact
+  communicate via the regular messaging channel to 1) exchange Bob's key and contact
   information and 2) to verify each other's keys.
   Note that this protocol only uses one out-of-band message requiring
   involvement of the user. All other messages
-  are sent in the channel potentially observed by a network adversary.
-  Note that this protocol only requires one *invite code* to be transferred without corruption.
-  All other messages are exchanged on the first channel controled by the network adversary.
+  are sent in the regular channel potentially controlled by a network adversary.
+  Note that this protocol only requires one *invite code* to be transferred un-observed.
+  All other messages are exchanged on the regular messaging channel controled by the network adversary.
 
 - the :ref:`Verified Group protocol <verified-group>` enables a user to invite
   another user to join a verified group as a new member.

--- a/source/summary.rst
+++ b/source/summary.rst
@@ -42,11 +42,11 @@ Attack model and terminology
 
 We consider
 
-- *Peer* devices that use the network or *first channel* for transporting messages
+- *Peer* devices that use network messages for transporting messages
   and for key-exchange in order to establish end-to-end encryption.
 
 - A *network adversary* that can read, modify, and create
-  network messages on the *first channel*.
+  network messages.
   Examples of such an adversary are an ISP, an e-mail provider, an AS,
   or an eavesdropper on a wireless network.
   The goal of the adversary is to i) read the content of messages,
@@ -57,32 +57,32 @@ We assume that
 - All peers are honest and do not collaborate with the network adversary.
 
 - A Peer (Alice) can send a single QR-code sized *invite code*
-  in a *second channel* to another peer (Bob).
+  in an *out-of-band channel* to another peer (Bob).
   The attacker can not observe or modify the invite code.
 
 The SecureJoin protocols allow *peer* devices
-to establish guaranteed end-to-end encryption
-that is resistant to machine-in-the-middle attacks by the network adversary,
+to establish *guaranteed end-to-end encryption*
+that is resistant to machine-in-the-middle attacks by
 preventing the adversary from reading messages or impersonating honest peers.
 
 Passive adversaries such as message transport providers can still learn
 which peers communicate with each other,
 at what time and the approximate size of the messages.
 
-An adversary who can observe Alice's invite code in the second channel
+An adversary who can observe Alice's invite code in the out-of-band channel
 can perform impersonation attacks.
 Additional measures can
-relax the security requirements for the *second channels*
+relax the security requirements for the out-of-band channel
 to also work under a threat of observation.
 
 ..
   TODO: Explain 'verified' and 'protected' terminology in the code,
-  and 'guaranteed' and 'green checkmark' terminology in thd UI
+  and 'green checkmark' terminology in thd UI
 
 Disadvantages of other key-verification techniques
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 
-An important aspect of secure end-to-end (e2e) encryption is the verification of
+An important aspect of guaranteed end-to-end (e2e) encryption is the verification of
 a peer's key.
 In many existing e2e-encrypting messengers like Signal or Element,
 users perform key verification by triggering two fingerprint verification workflows:

--- a/source/summary.rst
+++ b/source/summary.rst
@@ -20,7 +20,7 @@ are not considered in the Level 1 specification.
 Yet,
 such active attackers might undermine the security of Autocrypt.
 Therefore,
-we present and discuss SecureJoin as a new practically usable
+we present and discuss SecureJoin protocols as a new, practically usable
 way to prevent and detect active network attacks
 against Autocrypt_-capable mail apps.
 
@@ -40,41 +40,40 @@ funded through the EU Horizon 2020 programme.
 Attack model and terminology
 ++++++++++++++++++++++++++++
 
-We consider a *network adversary* that can read, modify, and create
-network messages.
-Examples of such an adversary are an ISP, an e-mail provider, an AS,
-or an eavesdropper on a wireless network.
-The goal of the adversary is to i) read the content of messages, ii)
-impersonate peers -- communication partners, and iii) to learn who communicates
-with whom.
-To achieve these goals,
-an active adversary might try, for example,
-to perform a machine-in-the-middle attack on the key exchange protocol
-between peers.
+We consider
 
-To enable secure key-exchange and key-verification between peers,
-we assume that peers have access to a *out-of-band*
-communication channel that cannot be observed or manipulated by the adversary.
-More concretely we expect them to be able
-to transfer a small amount of data via a QR-code confidentially.
+- *Peer* devices that use the network or *first channel* for transporting messages
+  and for key-exchange in order to establish end-to-end encryption.
 
-Targeted attacks on end devices or the out-of-band channels
-can break our assumptions
-and therefore the security properties of the protocols described.
-In particular
-the ability to observe QR-codes in the scan process
-(for example through CCTV or by getting access to print outs)
-will allow impersonation attacks.
+- A *network adversary* that can read, modify, and create
+  network messages on the *first channel*.
+  Examples of such an adversary are an ISP, an e-mail provider, an AS,
+  or an eavesdropper on a wireless network.
+  The goal of the adversary is to i) read the content of messages,
+  and to ii) impersonate *peer* devices.
+
+We assume that
+
+- All peers are honest and do not collaborate with the network adversary.
+
+- A Peer (Alice) can send a single QR-code sized *invite code*
+  in a *second channel* to another peer (Bob).
+  The attacker can not observe or modify the invite code.
+
+The SecureJoin protocols allow *peer* devices
+to establish guaranteed end-to-end encryption
+that is resistant to machine-in-the-middle attacks by the network adversary,
+preventing the adversary from reading messages or impersonating honest peers.
+
+Passive adversaries such as message transport providers can still learn
+which peers communicate with each other,
+at what time and the approximate size of the messages.
+
+An adversary who can observe Alice's invite code in the second channel
+can perform impersonation attacks.
 Additional measures can
-relax the security requirements for the *out-of-band* channel
+relax the security requirements for the *second channels*
 to also work under a threat of observation.
-
-Passive attackers such as service providers can still learn who
-communicates with whom at what time and the approximate size of the messages.
-
-Because peers learn the content of the messages,
-we assume that all peers are honest.
-They do not collaborate with the adversary and follow the protocols described in this document.
 
 ..
   TODO: Explain 'verified' and 'protected' terminology in the code,
@@ -121,32 +120,35 @@ by integrating key verification into existing messaging use cases:
   Alice and Bob know each other's contact information and
   have verified each other's keys.
   To do so,
-  Alice sends bootstrap data using the trusted out-of-band channel to Bob (for
+  Alice sends an *invite code* using using the second channel to Bob (for
   example, by showing QR code).
-  The bootstrap data
+  The invite code
   transfers not only the key fingerprint,
   but also contact information (e.g., email address).
-  After receiving the out-of-band bootstrap data, Alice's and Bob's clients
-  communicate via the regular channel to 1) exchange Bob's key and contact
+  After receiving the second-channel invite code, Alice's and Bob's clients
+  communicate via the first channel to 1) exchange Bob's key and contact
   information and 2) to verify each other's keys.
   Note that this protocol only uses one out-of-band message requiring
   involvement of the user. All other messages
   are sent in the channel potentially observed by a network adversary.
+  Note that this protocol only requires one *invite code* to be transferred without corruption.
+  All other messages are exchanged on the first channel controled by the network adversary.
 
 - the :ref:`Verified Group protocol <verified-group>` enables a user to invite
-  another user to join a verified group.
-  The "joining" peer establishes verified contact with the inviter,
+  another user to join a verified group as a new member.
+  This protocol builds on top of the previous protocol.
+  The "joining" peer first establishes verified contact with the inviter,
   and the inviter then announces the joiner as a new member. At the end of this
   protocol, the "joining" peer has learned the keys of all members of the group.
-  This protocol builds on top of the previous protocol.
-  But, this time, the bootstrap data functions as an invite code to the group.
 
-  Any member may invite new members.
+  Any group member may invite new members.
   By introducing members in this incremental way,
   a group of size :math:`N` requires only :math:`N-1` verifications overall
   to ensure that a network adversary can not compromise end-to-end encryption
   between group members. If one group member loses her key (e.g. through device loss),
   she must re-join the group via invitation of the remaining members of the verified group.
+
+.. TODO: this subsection is superflous / redundant and should be merged with what is in new.rst
 
 
 .. _autocrypt: https://autocrypt.org


### PR DESCRIPTION
- use 'invite code' instead of 'bootstrap' code throughout the doc. 
- refactor "attack model and terminology" to talk about 'first' and 'second channels', and in particular the ability to send an unobservable invite code in the second channel.   

